### PR TITLE
use hostname directly

### DIFF
--- a/deployment/docker-swarm/docker-compose.yml
+++ b/deployment/docker-swarm/docker-compose.yml
@@ -255,6 +255,8 @@ services:
             MQTTHOST: 'mqtt'
             STORAGE_VOLUME: '/home/video-analytics/app/server/recordings'
             EVERY_NTH_FRAME: 6
+        dns:
+            - 127.0.0.11
         volumes:
             - ${STORAGE_VOLUME}:/home/video-analytics/app/server/recordings:rw
             - /etc/localtime:/etc/localtime:ro

--- a/deployment/docker-swarm/docker-compose.yml
+++ b/deployment/docker-swarm/docker-compose.yml
@@ -255,8 +255,6 @@ services:
             MQTTHOST: 'mqtt'
             STORAGE_VOLUME: '/home/video-analytics/app/server/recordings'
             EVERY_NTH_FRAME: 6
-        dns:
-            - 127.0.0.11
         volumes:
             - ${STORAGE_VOLUME}:/home/video-analytics/app/server/recordings:rw
             - /etc/localtime:/etc/localtime:ro

--- a/sensor/simulation/main.py
+++ b/sensor/simulation/main.py
@@ -23,7 +23,7 @@ resolution=list(map(int,os.environ["RESOLUTION"].split("x")))
 dbhost=os.environ["DBHOST"]
 
 pattern=str(os.environ["FILES"])
-hostname=socket.gethostbyname(socket.gethostname())
+hostname=socket.gethostname()
 
 theta = float(os.environ["THETA"])
 mnth = float(os.environ["MNTH"])


### PR DESCRIPTION
Must avoid IP addresses so that the sample can be reconfigured in a multiple-network environment.
