### PR TITLE
remove input preproc instructions

### DIFF
--- a/analytics/entrance/models/person_reidentification_2021R1/1/person-reidentification-retail-0277.json
+++ b/analytics/entrance/models/person_reidentification_2021R1/1/person-reidentification-retail-0277.json
@@ -1,14 +1,9 @@
 {
   "json_schema_version" : "1.0.0",
-  "input_preproc": [
-    {
-      "layer_name": "data",
-      "color_format": "BGR"
-    }
-  ],
+  "input_preproc": [],
   "output_postproc": [
     {
-      "layer_name": "embd/dim_red/conv",
+      "layer_name": "reid_embedding",
       "attribute_name": "face_feature",
       "format": "cosine_distance"
     }


### PR DESCRIPTION
With the latest DL Streamer - including pre-processing instructions for this model causes an error. As a work around - the instructions can be removed.